### PR TITLE
refacto(view): use wp's wp_required_field_indicator instead of reinventing the same feature

### DIFF
--- a/src/FormView.php
+++ b/src/FormView.php
@@ -679,7 +679,7 @@ class FormView implements FormViewInterface
         $validationRules = $field->getValidationRules();
 
         if ($field->getType() !== 'radio' && $validator::hasRule($validationRules, NotEmpty::class)) {
-            $label .= '<span class="required">*</span>';
+            $label .= wp_required_field_indicator();
         }
 
         return $label;


### PR DESCRIPTION
It has the same markup, which is retro compatible, plus it has a useful filter.